### PR TITLE
Multimapping and PE reads support, fix ref coordinates for reversed mappings, empty CIGARs and wrong query coordinates, refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "gfainject"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "btoi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfainject"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -681,7 +681,7 @@ fn gbam_injection(path_index: PathIndex, gbam_path: PathBuf) -> Result<()> {
             ref_name: ref_name.to_string(),
             read_name: read_name.clone(),
             read_len: rec.cigar.as_ref().unwrap().read_length() as usize,
-            start_pos: (start - 1) as u32,
+            start_pos: start as u32, // already 0-based
             is_reverse: rec.is_reverse_complemented(),
             cigar_str: rec.cigar.as_ref().unwrap().to_string(),
             mapping_quality: rec.mapq.unwrap_or(255),

--- a/src/main.rs
+++ b/src/main.rs
@@ -643,7 +643,7 @@ fn bam_injection(path_index: PathIndex, bam_path: PathBuf, include_multimapping:
                             ref_start_pos: alt_hit.pos - 1,
                             is_reverse: !alt_hit.strand,
                             cigar_str: alt_hit.cigar,
-                            mapping_quality: 0,
+                            mapping_quality: 255,
                         };
                         process_alignment(alt_alignment, &path_index, &mut stdout)?;
                     }
@@ -749,7 +749,7 @@ fn gbam_injection(path_index: PathIndex, gbam_path: PathBuf, include_multimappin
                             ref_start_pos: alt_hit.pos - 1,
                             is_reverse: !alt_hit.strand,
                             cigar_str: alt_hit.cigar,
-                            mapping_quality: 0,
+                            mapping_quality: 255,
                         };
                         process_alignment(alt_alignment, &path_index, &mut stdout)?;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,9 +361,9 @@ fn process_query_name(query_name: &str, flags: SamFlagInfo) -> String {
     
     // Add appropriate suffix based on first/second read
     if flags.is_first {
-        format!("{}_R1", query_name)
+        format!("{}/1", query_name)
     } else if flags.is_second {
-        format!("{}_R2", query_name)
+        format!("{}/2", query_name)
     } else {
         query_name.to_string()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,6 +718,10 @@ fn paf_injection(path_index: PathIndex, paf_path: PathBuf) -> Result<()> {
         let cigar_str = fields.iter().find(|&&f| f.starts_with("cg:Z:"))
             .map(|&f| &f[5..])
             .unwrap_or("");
+        if cigar_str.is_empty() || cigar_str == "*" {
+            continue;
+        }
+        
         let (alignment_span, matches) = calculate_alignment_stats(cigar_str);
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use clap::{Parser, ArgGroup};
 ))]
 struct Args {
     /// Path to input GFA file
-    #[arg(short, long, required = true)]
+    #[arg(long, required = true)]
     gfa: PathBuf,
 
     /// Path to input BAM file

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,8 +98,8 @@ struct PathIndex {
 }
 
 struct PathStepRangeIter<'a> {
-    path_id: usize,
-    pos_range: std::ops::Range<u32>,
+    // path_id: usize,
+    // pos_range: std::ops::Range<u32>,
     // start_pos: usize,
     // end_pos: usize,
     steps: Box<dyn Iterator<Item = (usize, &'a PathStep)> + 'a>,
@@ -146,8 +146,8 @@ impl PathIndex {
         };
 
         Some(PathStepRangeIter {
-            path_id,
-            pos_range,
+            // path_id,
+            // pos_range,
             steps,
             // first_step_start_pos,
             // last_step_end_pos,
@@ -321,7 +321,7 @@ struct AlternativeHit {
     strand: bool,  // true for forward (+), false for reverse (-)
     pos: u32,
     cigar: String,
-    nm: u32,
+    // nm: u32,
 }
 
 impl AlternativeHit {
@@ -341,14 +341,14 @@ impl AlternativeHit {
             return None;
         };
         let cigar = parts[2].to_string();
-        let nm = parts[3].parse::<u32>().ok()?;
+        let _nm = parts[3].parse::<u32>().ok()?;
 
         Some(AlternativeHit {
             chr,
             strand,
             pos,
             cigar,
-            nm,
+            // nm,
         })
     }
 }


### PR DESCRIPTION
# Changes
- Added support for multi-mapping reads in BAM and GBAM formats
- Fixed MAPQ handling for XA mappings (now set to 255 to distinguish them)
- Implemented proper handling of paired-end (PE) reads with standard suffixes (/1, /2)
- Corrected query coordinate calculations 
- Fixed by1 bug in reverse strand handling
- Refactored code to reduce duplication and computations
- Added safety check for empty or unavailable CIGAR strings
